### PR TITLE
fix: prevent page from flickering when refreshing

### DIFF
--- a/pages/currently-playing.vue
+++ b/pages/currently-playing.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="pending" class="bg-spotify-dark min-h-screen grid place-items-center">
+    <div v-if="pending && !playbackState" class="bg-spotify-dark min-h-screen grid place-items-center">
       <div class="text-center">
         <h1 class="text-4xl text-spotify-green">
           Loading...


### PR DESCRIPTION
Currently, the layout flickers because it changes whenever `pending` is true. We should check for `pending && !data`